### PR TITLE
Add Docker build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Build and publish Docker container
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #3 

It was a bit longer ago then I remembered last touching Docker stuff on GitHub Actions (most of my more recent experience is on GitLab CI and Woodpecker CI, which I personally prefer).

Given my outdated knowledge, I decided to base this on the official suggested GitHub action and then updated the dependencies and simplified it to only leave in the basic stuff.

The current setup is as follows:
1. Each commit to the master branch will create a new container with the tag "master".
2. Each new tag matching `v*.*.*` creates a new container with the tag "latest" and the tag itself. Do note that this is based on the tag, not on releases, so creating a pre-release will also mark it as "latest"
3. During pull requests the container is built but then not uploaded anywhere (so changes that will cause build failures can be detected easily)

Feel free to click around on https://github.com/TheLastProject/fruitstand and look at https://github.com/TheLastProject/fruitstand/pkgs/container/fruitstand to see my experimenting (after this is merged, I'll delete that project to clean up again).