### PR TITLE
Actually run chrome in --no-sandbox mode

### DIFF
--- a/render.js
+++ b/render.js
@@ -29,7 +29,8 @@ if (options.browser == 'firefox') {
 
 if (options.browser == 'chrome') {
   browserConfig.args = [
-    '--no-sandbox --disable-gpu'
+    '--no-sandbox',
+    '--disable-gpu'
   ];
 }
 


### PR DESCRIPTION
Each entry in the `args` list is given separately. By not separating the list entries, Chrome actually receives this as a single argument `--no-sandbox --disable-gpu` instead of the 2 arguments `--no-sandbox` and `--disable-gpu` and thus ignores it as it is an "invalid argument".