### PR TITLE
Simplify Docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,31 +1,21 @@
 services:
-  web:
-    image: nginx:1.29-alpine
-    restart: always
-    depends_on:
-      - app
-    ports:
-      - 8000:80
-    volumes:
-      - ./local-nginx.conf:/etc/nginx/conf.d/default.conf:ro
-
   app:
-    build: .
+    image: ghcr.io/basementcat/fruitstand:master
     command: [
       '--processes=4',
       '--py-autoreload=1',
-      '--socket=0.0.0.0:3031',
-      '--protocol=uwsgi',
+      '--http-socket=0.0.0.0:3031'
     ]
+    ports:
+      - 3031:3031
     restart: always
     depends_on:
       - db
     environment:
       - FRUITSTAND_SECRET_KEY=lkasdjfalsdkjflskjdklsjdflk
       - FRUITSTAND_SQLALCHEMY_DATABASE_URI=mysql+pymysql://fruitstand:password@db:3306/fruitstand
+      - FRUITSTAND_CACHE_DRIVER=database
       - FRUITSTAND_INTERNAL_WEB_HOST=web
-    volumes:
-      - .:/app
 
   db:
     image: mariadb:lts
@@ -40,11 +30,5 @@ services:
     volumes:
       - db-data:/var/lib/mysql
 
-  # mail:
-  #   image: mailhog/mailhog
-  #   restart: always
-  #   ports:
-  #     - '1025:1025'
-  #     - '8025:8025'
 volumes:
-  db-data: {}
+  db-data:


### PR DESCRIPTION
I'll admit this one is a bit of a personal opinion, feel free to reject, but I think the simplest Docker Compose is probably the most useful for most people. This is basically the config I use myself now :)

Feel free to deny if you disagree.

As explanation:
- When using a http-socket, the NGINX is not necessary.
- Also sets cache driver to database due to https://github.com/BasementCat/fruitstand/issues/13